### PR TITLE
Add random starting offset option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Discussion thread: https://bitcointalk.org/index.php?topic=5517607
 <b>-pubkey</b>		public key to solve, both compressed and uncompressed keys are supported. If not specified, software starts in benchmark mode and solves random keys. 
 
 <b>-start</b>		start offset of the key, in hex. Mandatory if "-pubkey" option is specified. For example, for puzzle #85 start offset is "1000000000000000000000". 
+<b>-rndstart</b>       generate random start offset inside the specified range. Requires "-range" option and overrides "-start".
 
 <b>-range</b>		bit range of private the key. Mandatory if "-pubkey" option is specified. For example, for puzzle #85 bit range is "84" (84 bits). Must be in range 32...170. 
 


### PR DESCRIPTION
## Summary
- let the tool pick a random start value with `-rndstart`
- document the new option in README

## Testing
- `make clean && make` *(fails: cuda_runtime.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ac85942c083338a5ecdbb03e6bc4a